### PR TITLE
Add two-column layout for artist cards on desktop

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,4 +1,20 @@
-@media only screen and (min-device-width: 320px) and (max-device-width: 800px) {
+body {
+  background-color: #fafafa;
+  padding-top: 64px;
+}
+
+.artist-list {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 8px;
+
+  app-artist-card {
+    width: 100%;
+    min-width: 0; // Prevents grid blowout
+  }
+}
+
+@media only screen and (min-width: 320px) and (max-width: 799px) {
   .container {
     width: 90%;
     margin: 0 auto;
@@ -6,36 +22,21 @@
 
   .artist-list {
     max-width: 460px;
-  }
-
-  .artist-list > *:not(:last-child) {
-    margin-bottom: 8px;
+    gap: 8px;
   }
 }
 
-@media only screen and (min-device-width: 800px) {
+@media only screen and (min-width: 800px) {
   .container {
-    width: 50%;
+    width: 85%;
     margin: 0 auto;
   }
 
   .artist-list {
-    max-width: 600px;
+    max-width: 1400px;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 24px;
   }
-
-  .artist-list > *:not(:last-child) {
-    margin-bottom: 16px;
-  }
-}
-
-body {
-  background-color: #fafafa;
-  padding-top: 64px;
-}
-
-.artist-list {
-  display: flex;
-  flex-direction: column;
 }
 
 // Enhanced login card styling

--- a/src/app/artist-card/artist-card.component.scss
+++ b/src/app/artist-card/artist-card.component.scss
@@ -1,6 +1,12 @@
+.card {
+  width: 100%;
+  box-sizing: border-box;
+}
+
 .mat-card-image {
   object-fit: cover;
   height: 400px;
+  width: 100%;
 }
 
 .mat-nav-list {


### PR DESCRIPTION
## Summary
Implements a responsive two-column grid layout for artist cards on desktop screens to better utilize available horizontal space.

**Changes:**
- Converted artist card list from flexbox to CSS Grid
- Desktop (≥800px): Two equal-width columns with 24px gap
- Mobile (<800px): Single column with 8px gap (maintains existing behavior)
- Fixed deprecated media queries (`min-device-width` → `min-width`)
- Ensured equal card widths with proper sizing constraints
- Increased desktop container width from 50% to 85%

## Visual Changes
- **Before**: Single column on all screen sizes
- **After**: Two columns on desktop (800px+), single column on mobile

## Technical Details
- Uses CSS Grid with `grid-template-columns: repeat(2, 1fr)` for equal-width columns
- Added `min-width: 0` to prevent grid blowout
- Added `width: 100%` and `box-sizing: border-box` to cards for consistent sizing
- Media queries now properly respond to viewport width instead of device width

## Test Plan
- [x] Tested on desktop (≥800px) - displays two equal-width columns
- [x] Tested on mobile (<800px) - displays single column
- [x] Verified cards have equal widths in both columns
- [x] Confirmed responsive behavior when resizing browser window

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced responsive layout for improved display across all device sizes.
  * Improved grid layout for artist card display on larger screens.
  * Added refined styling for artist cards with better spacing and visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->