### PR TITLE
Hide app title icon on mobile screens

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -190,6 +190,10 @@ h1 {
   .sticky-nav {
     gap: 6px;
 
+    .header-icon {
+      display: none;
+    }
+
     .title {
       font-size: 16px;
     }


### PR DESCRIPTION
Fixes #16 by adding display: none to .header-icon within the existing mobile media query (max-width: 599px). This prevents the icon from showing partially/truncated on smaller screens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Optimized responsive design by hiding the header icon element on smaller screens. This enhancement improves mobile usability and provides better screen space utilization on narrow viewports, ensuring a cleaner user interface across all device sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->